### PR TITLE
Add Azure credentials configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+AZURE_SPEECH_ENDPOINT=https://<your-speech-resource>.cognitiveservices.azure.com/
+AZURE_SPEECH_KEY=YOUR_SPEECH_API_KEY
+AZURE_AUDIO_ENDPOINT=https://<your-audio-resource>.cognitiveservices.azure.com/
+AZURE_AUDIO_KEY=YOUR_AUDIO_API_KEY
+AZURE_OPENAI_ENDPOINT=https://<your-openai-resource>.openai.azure.com/
+AZURE_OPENAI_KEY=YOUR_OPENAI_API_KEY

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__/
 *.pyc
 .env/
+.env
 venv/

--- a/README.md
+++ b/README.md
@@ -68,6 +68,21 @@ Run the development server with:
 uvicorn app.main:app --reload
 ```
 
+### Environment Variables
+
+Copy `.env.example` to `.env` and add your Azure resource credentials:
+
+```bash
+cp .env.example .env
+# Edit .env and provide endpoint URLs and API keys
+```
+
+The application expects the following variables:
+
+* `AZURE_SPEECH_ENDPOINT` and `AZURE_SPEECH_KEY`
+* `AZURE_AUDIO_ENDPOINT` and `AZURE_AUDIO_KEY`
+* `AZURE_OPENAI_ENDPOINT` and `AZURE_OPENAI_KEY`
+
 ## Development Roadmap
 
 1. **Setup and Configuration**

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,8 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Depends
+from app.utils.config import Settings, get_settings
 
 app = FastAPI()
 
 @app.get('/health')
-def health():
+def health(settings: Settings = Depends(get_settings)):
     return {"status": "ok"}

--- a/app/utils/config.py
+++ b/app/utils/config.py
@@ -1,0 +1,19 @@
+import os
+from dataclasses import dataclass
+from functools import lru_cache
+from dotenv import load_dotenv
+
+load_dotenv()
+
+@dataclass
+class Settings:
+    speech_endpoint: str | None = os.getenv("AZURE_SPEECH_ENDPOINT")
+    speech_key: str | None = os.getenv("AZURE_SPEECH_KEY")
+    audio_endpoint: str | None = os.getenv("AZURE_AUDIO_ENDPOINT")
+    audio_key: str | None = os.getenv("AZURE_AUDIO_KEY")
+    openai_endpoint: str | None = os.getenv("AZURE_OPENAI_ENDPOINT")
+    openai_key: str | None = os.getenv("AZURE_OPENAI_KEY")
+
+@lru_cache()
+def get_settings() -> Settings:
+    return Settings()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn
+python-dotenv


### PR DESCRIPTION
## Summary
- add example .env file for Azure service credentials
- load environment variables in a `Settings` helper using `dotenv`
- expose `Settings` in `health` endpoint
- update gitignore for `.env`
- document required environment variables in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`