### PR TITLE
Improve audio handling endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+app/tmp/

--- a/README.md
+++ b/README.md
@@ -85,3 +85,19 @@ This project aims to develop a Python-based proof-of-concept (PoC) web applicati
 * Gather stakeholder feedback and iterate based on insights.
 * Expand capabilities towards production-grade application.
 * Explore additional integration opportunities with emergency response systems.
+
+## Running the PoC server
+
+Install requirements and start the FastAPI server using Uvicorn:
+
+```bash
+pip install -r requirements.txt
+uvicorn app.main:app --reload
+```
+
+### New API Endpoints
+
+* `POST /upload-audio` - Accepts an audio file along with `latitude` and `longitude` form fields. The file is temporarily stored on the server for further processing.
+* `WebSocket /ws/audio` - Accepts streaming audio bytes. Include `latitude` and `longitude` query parameters when connecting. Each received chunk is stored in a temporary directory on the server along with a metadata file for the connection.
+
+Geolocation values are currently simulated by the client and included as request data.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,63 @@
+from fastapi import FastAPI, UploadFile, File, Form, WebSocket, WebSocketDisconnect, HTTPException
+import os
+import uuid
+
+app = FastAPI()
+
+TMP_DIR = os.path.join(os.path.dirname(__file__), "tmp")
+os.makedirs(TMP_DIR, exist_ok=True)
+
+@app.post("/upload-audio")
+async def upload_audio(
+    file: UploadFile = File(...),
+    latitude: float = Form(...),
+    longitude: float = Form(...),
+):
+    """Receive an audio file and associated geolocation metadata."""
+    if not file.content_type or not file.content_type.startswith("audio/"):
+        raise HTTPException(status_code=400, detail="Unsupported file type")
+
+    file_id = str(uuid.uuid4())
+    temp_path = os.path.join(TMP_DIR, f"{file_id}_{file.filename}")
+    with open(temp_path, "wb") as f:
+        content = await file.read()
+        f.write(content)
+
+    # Placeholder: send file to Azure APIs here
+
+    return {
+        "file_id": file_id,
+        "saved_to": temp_path,
+        "latitude": latitude,
+        "longitude": longitude,
+    }
+
+@app.websocket("/ws/audio")
+async def websocket_endpoint(
+    websocket: WebSocket,
+    latitude: float,
+    longitude: float,
+):
+    await websocket.accept()
+    try:
+        # Generate a unique id per connection to store streamed chunks
+        conn_id = str(uuid.uuid4())
+        conn_dir = os.path.join(TMP_DIR, conn_id)
+        os.makedirs(conn_dir, exist_ok=True)
+
+        # Save geolocation metadata for the connection
+        with open(os.path.join(conn_dir, "metadata.txt"), "w") as meta:
+            meta.write(f"{latitude},{longitude}")
+
+        index = 0
+        while True:
+            data = await websocket.receive_bytes()
+            chunk_path = os.path.join(conn_dir, f"chunk_{index}.wav")
+            with open(chunk_path, "wb") as chunk_file:
+                chunk_file.write(data)
+            index += 1
+            # Placeholder: stream chunk to Azure APIs here
+    except WebSocketDisconnect:
+        pass
+    finally:
+        await websocket.close()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn


### PR DESCRIPTION
## Summary
- validate audio uploads and reject non-audio files
- capture geolocation metadata for WebSocket connections
- document query parameters for `/ws/audio`
- ignore tmp and cache files

## Testing
- `python -m py_compile app/main.py`
- `pytest -q` *(fails: command not found)*